### PR TITLE
Create empty shapefile

### DIFF
--- a/lidar_prod/tasks/building_validation.py
+++ b/lidar_prod/tasks/building_validation.py
@@ -96,7 +96,7 @@ class BuildingValidator:
         self.pipeline = get_pipeline(input_values)
         with TemporaryDirectory() as td:
             log.info(
-                "Preparation : Clustering of candidates buildings & Requesting BDUni"
+                "Preparation : Clustering of candidates buildings & Import vectors"
             )
             if type(input_values) == str:
                 log.info(f"Applying Building Validation to file \n{input_values}")
@@ -177,6 +177,7 @@ class BuildingValidator:
         if self.shp_path:
             temp_dirpath = None  # no need for a temporay directory to add the shapefile in it, we already have the shapefile
             _shp_p = self.shp_path
+            log.info(f"Read shapefile\n {_shp_p}")
             gdf = geopandas.read_file(_shp_p)
             buildings_in_bd_topo = (
                 not len(gdf) == 0
@@ -187,6 +188,7 @@ class BuildingValidator:
             # TODO: extract coordinates from LAS directly using pdal.
             # Request BDUni to get a shapefile of the known buildings in the LAS
             _shp_p = os.path.join(temp_dirpath, "temp.shp")
+            log.info("Request Bd Uni")
             buildings_in_bd_topo = request_bd_uni_for_building_shapefile(
                 self.bd_uni_connection_params, _shp_p, bbox
             )

--- a/lidar_prod/tasks/utils.py
+++ b/lidar_prod/tasks/utils.py
@@ -183,6 +183,13 @@ def request_bd_uni_for_building_shapefile(
     except subprocess.CalledProcessError as e:
         # In empty zones, pgsql2shp does not create a shapefile
         if e.output == b"Initializing... \nERROR: Could not determine table metadata (empty table)\n":
+
+            # write empty shapefile
+            df = geopandas.GeoDataFrame(
+                columns=["id", "geometry"],
+                geometry="geometry", crs=f"EPSG:{Lambert_93_SRID}")
+            df.to_file(shapefile_path)
+
             return False
         # Error can be due to something else entirely, like
         # an inability to translate host name to an address.

--- a/package_metadata.yaml
+++ b/package_metadata.yaml
@@ -1,4 +1,4 @@
-__version__: "M11.1V1.9.5"
+__version__: "M11.1V1.9.6"
 __name__: "lidar_prod"
 __url__: "https://github.com/IGNF/lidar-prod-quality-control"
 __description__: "A 3D semantic segmentation production tool to augment rule- based Lidar classification with AI and databases."


### PR DESCRIPTION
- Vector extraction : Create an empty shapefile. Needed because pgsql2shp does not create shapefile when there is no vector.
- Improve logs : log  'request bd uni' only when we request database.
- bump version to M11.1V1.9.6