### PR TITLE
Run CICD for "staging-*" branches

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -4,15 +4,13 @@ on:
   # Run CICD for non-draft pull request
   pull_request:
     branches:
-      - dev
       - main
   # Also run when the pull request merges (which generates a push)
   # So that we can tag the docker image appropriately.
   push:
     branches:
-      - dev
-      - prod
       - main
+      - staging-*
 env:
   nexus_server: 10.128.81.69:8082
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # main
 
+# 1.9.13
+- Run CICD operations for all branches prefixed with "staging-"
+
 # 1.9.12
 - Instantiate bd_uni_connection_params externally to fix BV optimization.
 

--- a/package_metadata.yaml
+++ b/package_metadata.yaml
@@ -1,4 +1,4 @@
-__version__: "V1.9.12"
+__version__: "V1.9.13"
 __name__: "lidar_prod"
 __url__: "https://github.com/IGNF/lidar-prod-quality-control"
 __description__: "A 3D semantic segmentation production tool to augment rule- based Lidar classification with AI and databases."


### PR DESCRIPTION
L'idée est d'être capable de générer une image docker et de la pusher sur le nexus pour toute branche préfixée de "staging-".

Même idée que pour https://github.com/IGNF/myria3d/pull/93