### PR TITLE
Be robust to pgsql2shp warnings when dealing with empty tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # main
 
+# 1.9.13
+- Be robust to pgsql2shp warnings when dealing with empty tables (i;e. no buildings).
+
 # 1.9.12
 - Instantiate bd_uni_connection_params externally to fix BV optimization.
 

--- a/lidar_prod/tasks/utils.py
+++ b/lidar_prod/tasks/utils.py
@@ -192,7 +192,7 @@ def request_bd_uni_for_building_shapefile(
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=120)
     except subprocess.CalledProcessError as e:
         # In empty zones, pgsql2shp does not create a shapefile
-        if e.output == b"Initializing... \nERROR: Could not determine table metadata (empty table)\n":
+        if b"Initializing... \nERROR: Could not determine table metadata (empty table)\n" in e.output:
 
             # write empty shapefile
             df = geopandas.GeoDataFrame(columns=["id", "geometry"], geometry="geometry", crs=f"EPSG:{Lambert_93_SRID}")

--- a/package_metadata.yaml
+++ b/package_metadata.yaml
@@ -1,4 +1,4 @@
-__version__: "V1.9.12"
+__version__: "V1.9.13"
 __name__: "lidar_prod"
 __url__: "https://github.com/IGNF/lidar-prod-quality-control"
 __description__: "A 3D semantic segmentation production tool to augment rule- based Lidar classification with AI and databases."

--- a/package_metadata.yaml
+++ b/package_metadata.yaml
@@ -1,4 +1,4 @@
-__version__: "V1.9.13"
+__version__: "V1.9.14"
 __name__: "lidar_prod"
 __url__: "https://github.com/IGNF/lidar-prod-quality-control"
 __description__: "A 3D semantic segmentation production tool to augment rule- based Lidar classification with AI and databases."


### PR DESCRIPTION
Be slightly more robust in case there are unrelated warnings in the subprocess trace.